### PR TITLE
Removed for header gpg key

### DIFF
--- a/layouts/bug-bounty/single.html
+++ b/layouts/bug-bounty/single.html
@@ -141,7 +141,7 @@
           <div class="col col-lg-9 col-ul-8 offset-ul-1 mbg1">
             <h2>{{ $.Params.content.sections.submission.headline }}</h2>
             <p>{{ $.Params.content.sections.submission.description.p1 | markdownify }}</p>
-            <p class="small">[GPG&#58; <a href="/keys/security@defichain.com.public.key" target="_blank">F7CE 1F52 D5ED 7EE3 FC37  4614 E2C1 1358 5F01 B88B</a>]</p>
+            <p class="small">[GPG&#58; <a href="/keys/security@defichain.com.public.key">F7CE 1F52 D5ED 7EE3 FC37  4614 E2C1 1358 5F01 B88B</a>]</p>
             <p>{{ $.Params.content.sections.submission.description.p2 | markdownify }}</p>
             <ul>
               {{ range $li := $.Param "content.sections.submission.description.list" }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@ publish = "public"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
 
 [[headers]]
-  for = "/keys/security@defichain.com.public.key"
+  for = "/*/keys/security@defichain.com.public.key"
   [headers.values]
     Content-Disposition = "inline"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,11 +12,6 @@ publish = "public"
     X-XSS-Protection = "1; mode=block"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
 
-[[headers]]
-  for = "/*/keys/security@defichain.com.public.key"
-  [headers.values]
-    Content-Disposition = "inline"
-
 [[redirects]]
   from = "http://defichain.com/*"
   to = "https://defichain.com/:splat"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Removed Content-Disposition for gpg key as it was not working as intended. This is due to the limitation of Netlify headers when proxying is being used.

Read More: https://docs.netlify.com/routing/headers/#limitations

#### Additional comments?:
