### PR TITLE
Add footer link for DeFiChainWiki

### DIFF
--- a/cypress/e2e/layout/footer.spec.ts
+++ b/cypress/e2e/layout/footer.spec.ts
@@ -54,6 +54,9 @@ context("<Footer/> on desktop", () => {
     cy.findByTestId("FooterSectionSitemap.Newsletter")
       .should("be.visible")
       .should("have.attr", "href", "https://bit.ly/3yQxtmW");
+    cy.findByTestId("FooterSectionSitemap.Wiki")
+      .should("be.visible")
+      .should("have.attr", "href", "https://defichainwiki.com");
   });
 
   it("should have Footer Social links", () => {
@@ -194,6 +197,9 @@ context("<Footer/> on mobile", () => {
     cy.findByTestId("FooterSectionSitemap.Newsletter")
       .should("be.visible")
       .should("have.attr", "href", "https://bit.ly/3yQxtmW");
+    cy.findByTestId("FooterSectionSitemap.Wiki")
+      .should("be.visible")
+      .should("have.attr", "href", "https://defichainwiki.com");
   });
 
   it("should have Footer Social links", () => {

--- a/public/locales/de/layout.json
+++ b/public/locales/de/layout.json
@@ -29,7 +29,8 @@
       "whitepaper": "White Paper",
       "dfcblog": "Blog",
       "language": "de",
-      "newsletter": "Newsletter"
+      "newsletter": "Newsletter",
+      "wiki": "Wiki"
     },
     "social": {
       "title": "Soziale Netze",

--- a/public/locales/en-US/layout.json
+++ b/public/locales/en-US/layout.json
@@ -29,7 +29,8 @@
       "whitepaper": "White Paper",
       "dfcblog": "Blog",
       "language": "en",
-      "newsletter": "Newsletter"
+      "newsletter": "Newsletter",
+      "wiki": "Wiki"
     },
     "social": {
       "title": "Social",

--- a/public/locales/fr/layout.json
+++ b/public/locales/fr/layout.json
@@ -28,7 +28,8 @@
       "whitepaper": "Livre blanc",
       "dfcblog": "Blog",
       "language": "fr",
-      "newsletter": "Newsletter"
+      "newsletter": "Newsletter",
+      "wiki": "Wiki"
     },
     "social": {
       "title": "Réseaux sociaux",

--- a/public/locales/zh-Hans/layout.json
+++ b/public/locales/zh-Hans/layout.json
@@ -28,7 +28,8 @@
       "whitepaper": "白皮书",
       "dfcblog": "博客",
       "language": "zh",
-      "newsletter": "Newsletter"
+      "newsletter": "Newsletter",
+      "wiki": "Wiki"
     },
     "social": {
       "title": "社区",

--- a/public/locales/zh-Hant/layout.json
+++ b/public/locales/zh-Hant/layout.json
@@ -28,7 +28,8 @@
       "whitepaper": "白皮書",
       "dfcblog": "博客",
       "language": "zh-tw",
-      "newsletter": "Newsletter"
+      "newsletter": "Newsletter",
+      "wiki": "Wiki"
     },
     "social": {
       "title": "社區",

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -141,6 +141,11 @@ function FooterSectionSitemap(): JSX.Element {
         url="https://bit.ly/3yQxtmW"
         testId="FooterSectionSitemap.Newsletter"
       />
+      <FooterExternalLink
+        text={t("footer.sitemap.wiki")}
+        url="https://defichainwiki.com"
+        testId="FooterSectionSitemap.Wiki"
+      />
     </FooterSection>
   );
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a link to the new defichainwiki.com site in the footer. This site provides a wealth of helpful articles about DeFiChain and will aid users in gaining a better understanding of the ecosystem.