### PR TITLE
fix(ui-ux): removed blockfolio from ecosystem page

### DIFF
--- a/cypress/e2e/pages/ecosystem.spec.ts
+++ b/cypress/e2e/pages/ecosystem.spec.ts
@@ -30,7 +30,6 @@ context("/ecosystem page on desktop", () => {
       cy.findByTestId("Section.Title").should("have.text", "Partners");
       cy.findByTestId("EcosystemSection.CakeDeFi").should("be.visible");
       cy.findByTestId("EcosystemSection.Staking").should("be.visible");
-      cy.findByTestId("EcosystemSection.Blockfolio").should("be.visible");
       cy.findByTestId("EcosystemSection.Blockspot").should("be.visible");
       cy.findByTestId("EcosystemSection.Messari").should("be.visible");
     });
@@ -69,7 +68,6 @@ context("/ecosystem page on mobile", () => {
       cy.findByTestId("Section.Title").should("have.text", "Partners");
       cy.findByTestId("EcosystemSection.CakeDeFi").should("be.visible");
       cy.findByTestId("EcosystemSection.Staking").should("be.visible");
-      cy.findByTestId("EcosystemSection.Blockfolio").should("be.visible");
       cy.findByTestId("EcosystemSection.Blockspot").should("be.visible");
       cy.findByTestId("EcosystemSection.Messari").should("be.visible");
     });

--- a/public/locales/de/page-ecosystem.json
+++ b/public/locales/de/page-ecosystem.json
@@ -32,11 +32,6 @@
       "desc": "DeFiChain (DFI)-Kurs, Grafik, Daten und Infos auf Blockspot.io",
       "button": "Weiter zu Blockspot.io"
     },
-    "Blockfolio": {
-      "title": "Blockfolio",
-      "desc": "Beobachte DFI auf der Plattform Blockfolio Signal",
-      "button": "Weiter zu Blockfolio"
-    },
     "Messari": {
       "title": "Messari",
       "desc": "Datentools, die Transparenz in die Kryptoökonomie bringen",

--- a/public/locales/en-US/page-ecosystem.json
+++ b/public/locales/en-US/page-ecosystem.json
@@ -32,11 +32,6 @@
       "desc": "DeFiChain (DFI) price, graph, data and info on Blockspot.io",
       "button": "Go to Blockspot.io"
     },
-    "Blockfolio": {
-      "title": "Blockfolio",
-      "desc": "Watch DFI on the Blockfolio Signal platform",
-      "button": "Go to Blockfolio"
-    },
     "Messari": {
       "title": "Messari",
       "desc": "Data tools that bring transparency to the cryptoeconomy",

--- a/public/locales/fr/page-ecosystem.json
+++ b/public/locales/fr/page-ecosystem.json
@@ -32,11 +32,6 @@
       "desc": "Le prix, le graphique, les données et les informations de DeFiChain (DFI) sur Blockspot.io",
       "button": "Aller sur Blockspot.io"
     },
-    "Blockfolio": {
-      "title": "Blockfolio",
-      "desc": "Regarder DFI sur la plateforme Blockfolio Signal",
-      "button": "Aller sur Blockfolio"
-    },
     "Messari": {
       "title": "Messari",
       "desc": "Des outils de données qui apportent de la transparence à la cryptoéconomie",

--- a/public/locales/zh-Hans/page-ecosystem.json
+++ b/public/locales/zh-Hans/page-ecosystem.json
@@ -32,11 +32,6 @@
       "desc": "递飞链（DFI）的价格，图表，数据及资讯",
       "button": "前往 Blockspot.io"
     },
-    "Blockfolio": {
-      "title": "Blockfolio",
-      "desc": "在Blockfolio資產追中APP上關注DFI",
-      "button": "前往 Blockfolio"
-    },
     "Messari": {
       "title": "Messari数据分析",
       "desc": "加密经济透明化的数据工具",

--- a/public/locales/zh-Hant/page-ecosystem.json
+++ b/public/locales/zh-Hant/page-ecosystem.json
@@ -32,11 +32,6 @@
       "desc": "遞飛鏈（DFI）的價格，圖表，數據及資訊",
       "button": "前往 Blockspot.io"
     },
-    "Blockfolio": {
-      "title": "Blockfolio",
-      "desc": "在Blockfolio資產追中APP上關注DFI",
-      "button": "前往 Blockfolio"
-    },
     "Messari": {
       "title": "Messari數據分析",
       "desc": "加密經濟透明化的數據工具",

--- a/src/pages/ecosystem/index.page.tsx
+++ b/src/pages/ecosystem/index.page.tsx
@@ -10,7 +10,6 @@ import { Section } from "@components/commons/Section";
 import CakeDeFiLogo from "../../../public/assets/svg/ecosystem/cake_logo.svg";
 import StakingRewardsLogo from "../../../public/assets/svg/ecosystem/stakingrewards_logo.svg";
 import BlockspotLogo from "../../../public/assets/img/ecosystem/blockspot.png";
-import Blockfolio from "../../../public/assets/svg/ecosystem/blockfolio_logo.svg";
 import MessariLogo from "../../../public/assets/svg/ecosystem/messari_logo.svg";
 import CoinGeckoLogo from "../../../public/assets/svg/ecosystem/coingecko_logo.svg";
 
@@ -86,18 +85,6 @@ export default function EcosystemPage(): JSX.Element {
             <Image alt="Blockspot Logo" src={BlockspotLogo} />
             <h3 className="text-2xl mt-5 font-medium">
               {t("PartnersSection.Blockspot.title")}
-            </h3>
-          </ResourceCard>
-          <ResourceCard
-            text={t("PartnersSection.Blockfolio.desc")}
-            buttonText={t("PartnersSection.Blockfolio.button")}
-            url="https://blockfolio.com/coin/DFI"
-            external
-            testid="EcosystemSection.Blockfolio"
-          >
-            <Image alt="Blockfolio Logo" src={Blockfolio} />
-            <h3 className="text-2xl mt-5 font-medium">
-              {t("PartnersSection.Blockfolio.title")}
             </h3>
           </ResourceCard>
           <ResourceCard


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Removed the blockfolio tile from ecosystem page as it was linked to a non-operational FTX page 

#### Additional comments?:
