### PR TITLE
chore(ui-ux): hide UI for non-mvp

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const securityHeaders = [
       `child-src 'self' app.netlify.com;` +
       `form-action 'none';` +
       `frame-ancestors 'none';` +
-      `img-src 'self' assets.coingecko.com s2.coinmarketcap.com *.cloudfront.net data:;` +
+      `img-src 'self' images.prismic.io assets.coingecko.com s2.coinmarketcap.com *.cloudfront.net data:;` +
       `media-src 'self';` +
       `object-src 'none';` +
       `script-src 'self' ajax.googleapis.com widgets.coingecko.com files.coinmarketcap.com 3rdparty-apis.coinmarketcap.com app.netlify.com netlify-cdp-loader.netlify.app ${
@@ -60,6 +60,6 @@ module.exports = {
     ];
   },
   images: {
-    domains: ['images.prismic.io'],
+    domains: ["images.prismic.io"],
   },
 };

--- a/src/components/commons/Buttons.tsx
+++ b/src/components/commons/Buttons.tsx
@@ -64,7 +64,7 @@ function ButtonElement({
       disabled={disabled}
       className={classNames(
         className ?? "py-4",
-        "flex items-center justify-center rounded-[92px] font-bold disabled:opacity-30 disabled:pointer-events-none min-w-[232px]",
+        "rounded-[92px] font-bold disabled:opacity-30 disabled:pointer-events-none min-w-[232px]",
         "bg-dark-1000 text-dark-100 hover:bg-brand-100 active:bg-brand-100 active:opacity-70"
       )}
     >

--- a/src/components/commons/SectionGridLayout.tsx
+++ b/src/components/commons/SectionGridLayout.tsx
@@ -51,19 +51,19 @@ export function SectionGridLayout(props: SectionGridLayoutProps): JSX.Element {
             >
               {description}
             </div>
-            {isCTAButton === true ? (
+            {isCTAButton === true && (
               <Button
-                className="z-10 text-sm !min-w-0 w-[188px] lg:text-base lg:w-[199px] py-3 lg:py-4"
+                className="z-10 text-sm lg:text-base px-14 py-3 lg:py-4 w-fit"
                 text={buttonText}
               />
-            ) : null}
-            {isSecondaryButton === true && href !== undefined ? (
+            )}
+            {isSecondaryButton === true && href !== undefined && (
               <SecondaryButton
                 className="text-sm w-[236px] py-3 lg:py-4 lg:text-base sm:w-[272px] !mt-[32px]"
                 text={buttonText}
                 href={href}
               />
-            ) : null}
+            )}
           </div>
         </div>
         <div className="z-0 justify-between md:gap-x-16 lg:w-[600px] lg:gap-x-[114px] w-full mt-16 md:mt-[86px] lg:mt-0">

--- a/src/components/index/BlockchainFeaturesSection.tsx
+++ b/src/components/index/BlockchainFeaturesSection.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@components/commons/Buttons";
+// import { Button } from "@components/commons/Buttons";
 import { Container } from "@components/commons/Container";
 import { useTranslation } from "next-i18next";
 import Slider from "react-slick";
@@ -77,10 +77,11 @@ export function BlockchainFeaturesSection(): JSX.Element {
             >
               {t("BlockchainFeatureSection.desc")}
             </div>
-            <Button
+            {/* TODO: uncomment after mvp */}
+            {/* <Button
               className="z-10 text-sm min-w-0 w-[206px] py-3 !mt-[23px] md:!mt-9 lg:text-base lg:w-[232px] lg:py-4 lg:!mt-10"
               text={t("BlockchainFeatureSection.button")}
-            />
+            /> */}
           </div>
         </div>
         <div className="z-10 justify-between hidden md:flex md:gap-x-16 lg:w-[568px] lg:gap-x-10 w-full lg:px-12 mt-14 md:mt-[72px] lg:mt-0">

--- a/src/components/index/ReadyForFlexibility.tsx
+++ b/src/components/index/ReadyForFlexibility.tsx
@@ -43,7 +43,8 @@ export function ReadyForFlexibility() {
 
           <Button
             text={t("ReadyForFlexibilitySection.button")}
-            className="lg:text-base text-sm lg:mt-16 mt-8 py-4 lg:w-[294px] w-[245px]"
+            className="lg:text-base text-sm lg:mt-16 mt-8 lg:py-4 py-3 lg:px-14 px-10"
+            href="https://meta.defichain.com/"
           />
         </div>
         <div

--- a/src/components/index/blogPosts/BlogPostsSection.tsx
+++ b/src/components/index/blogPosts/BlogPostsSection.tsx
@@ -22,7 +22,7 @@ export function BlogPostsSection({ blogPosts }: { blogPosts: Posts[] }) {
             </div>
             <Button
               text={t("BlogPostsSection.button")}
-              className="text-sm mt-9 py-4 w-[272px] lg:w-[232px] lg:text-base lg:mt-12"
+              className="text-sm mt-9 lg:py-4 lg:px-14 py-3 px-10 lg:text-base lg:mt-12"
               href="https://blog.defichain.com/"
             />
           </div>

--- a/src/pages/explore/dfi/_components/GetDFISection.tsx
+++ b/src/pages/explore/dfi/_components/GetDFISection.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Container } from "@components/commons/Container";
 import { SectionTitle } from "@components/commons/SectionTitle";
 import { useTranslation } from "next-i18next";
@@ -10,8 +10,8 @@ import CoinMarketCapIcon from "@components/icons/assets/exploreGetDFI/CoinMarket
 import GetDFISectionExchanges from "./GetDFISectionExchanges";
 
 export default function GetDFISection() {
-  const [coinMarketCapPrice, setCoinMarketCapPrice] = useState<string>();
-  const [coinGeckoPrice, setCoinGeckoPrice] = useState<string>();
+  // const [coinMarketCapPrice, setCoinMarketCapPrice] = useState<string>();
+  // const [coinGeckoPrice, setCoinGeckoPrice] = useState<string>();
   const { t } = useTranslation("page-explore-dfi");
 
   useEffect(() => {
@@ -27,37 +27,38 @@ export default function GetDFISection() {
     }
   });
 
-  const getDFIPriceFromCoinMarketCap = async () => {
-    try {
-      const response = await fetch(
-        "https://3rdparty-apis.coinmarketcap.com/v1/cryptocurrency/widget?id=5804&convert_id=1,2781,2781"
-      );
-      const data = await response.json();
-      const dfiId = 5804;
-      const usdFiatId = 2781;
-      const price = data?.data?.[dfiId]?.quote[usdFiatId]?.price;
-      setCoinMarketCapPrice(price);
-    } catch (e) {
-      setCoinMarketCapPrice(undefined);
-    }
-  };
+  // TODO: uncomment after mvp
+  // const getDFIPriceFromCoinMarketCap = async () => {
+  //   try {
+  //     const response = await fetch(
+  //       "https://3rdparty-apis.coinmarketcap.com/v1/cryptocurrency/widget?id=5804&convert_id=1,2781,2781"
+  //     );
+  //     const data = await response.json();
+  //     const dfiId = 5804;
+  //     const usdFiatId = 2781;
+  //     const price = data?.data?.[dfiId]?.quote[usdFiatId]?.price;
+  //     setCoinMarketCapPrice(price);
+  //   } catch (e) {
+  //     setCoinMarketCapPrice(undefined);
+  //   }
+  // };
 
-  const getDFIPriceFromCoinGecko = async () => {
-    try {
-      const response = await fetch(
-        "https://api.coingecko.com/api/v3/coins/defichain?developer_data=false&community_data=false&tickers=false"
-      );
-      const data = await response.json();
-      const price = data?.market_data?.current_price.usd;
-      setCoinGeckoPrice(price);
-    } catch (e) {
-      setCoinGeckoPrice(undefined);
-    }
-  };
+  // const getDFIPriceFromCoinGecko = async () => {
+  //   try {
+  //     const response = await fetch(
+  //       "https://api.coingecko.com/api/v3/coins/defichain?developer_data=false&community_data=false&tickers=false"
+  //     );
+  //     const data = await response.json();
+  //     const price = data?.market_data?.current_price.usd;
+  //     setCoinGeckoPrice(price);
+  //   } catch (e) {
+  //     setCoinGeckoPrice(undefined);
+  //   }
+  // };
 
   useEffect(() => {
-    getDFIPriceFromCoinMarketCap();
-    getDFIPriceFromCoinGecko();
+    // getDFIPriceFromCoinMarketCap();
+    // getDFIPriceFromCoinGecko();
   }, []);
 
   return (
@@ -92,7 +93,8 @@ export default function GetDFISection() {
           <p>{t("getDfiSection.desc2")}</p>
         </div>
         {/* DFI price from CoinMarketCap and CoinGecko */}
-        <div className="w-full md:w-fit lg:w-full text-center mt-3">
+        {/* TODO: uncomment after mvp */}
+        {/* <div className="w-full md:w-fit lg:w-full text-center mt-3">
           <div className="grid grid-cols-2 items-center divide-x divide-dark-200 border-[0.5px] border-dark-200 rounded-[15px] bg-dark-00 backdrop-blur bg-opacity-90 py-6">
             <DfiPrice
               name="marketCap"
@@ -108,14 +110,14 @@ export default function GetDFISection() {
           <div className="text-dark-700 tracking-[0.03em] text-xs lg:text-sm mt-2">
             {t("getDfiSection.exhangePriceText")}
           </div>
-        </div>
+        </div> */}
       </div>
       {/* Exchanges */}
       <GetDFISectionExchanges />
     </Container>
   );
 }
-
+// eslint-disable-next-line
 function DfiPrice({
   name,
   price,

--- a/src/pages/explore/dfi/_components/InitialTokenDistributionSection.tsx
+++ b/src/pages/explore/dfi/_components/InitialTokenDistributionSection.tsx
@@ -28,7 +28,7 @@ export function InitialTokenDistributionSection() {
 
         <Button
           text={t("initialTokenDistributionSection.button")}
-          className="mt-6 w-fit px-10 py-3"
+          className="mt-6 w-fit px-10 py-3 lg:px-14 lg:py-4"
         />
 
         <ProgressBar value={49} containerClass="bg-dark-200 mt-16 mb-8" />

--- a/src/pages/explore/dfi/index.page.tsx
+++ b/src/pages/explore/dfi/index.page.tsx
@@ -1,11 +1,11 @@
 import { HeroBanner, HeroBannerBg } from "@components/commons/HeroBanner";
 import { SSRConfig, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { Container } from "@components/commons/Container";
+// import { Container } from "@components/commons/Container";
 import { DFIStatisticsDisplay } from "./_components/DFIStatisticsDisplay";
 import HarnessDFISection from "./_components/HarnessDFISection";
 import GetDFISection from "./_components/GetDFISection";
-import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
+// import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
 import { InitialTokenDistributionSection } from "./_components/InitialTokenDistributionSection";
 import ERC20Section from "./_components/ERC20Section";
 
@@ -26,7 +26,8 @@ export default function ExploreDFI() {
       <InitialTokenDistributionSection />
       <GetDFISection />
       <ERC20Section />
-      <Container className="lg:mb-8 md:mb-6 mb-4">
+      {/* TODO: uncomment after mvp */}
+      {/* <Container className="lg:mb-8 md:mb-6 mb-4">
         <div className="flex flex-row overflow-x-scroll lg:gap-x-8 md:gap-x-6 gap-x-4">
           <ExploreCards
             title={t("footerCards.wallet.title")}
@@ -41,7 +42,7 @@ export default function ExploreDFI() {
             href=""
           />
         </div>
-      </Container>
+      </Container> */}
     </>
   );
 }

--- a/src/pages/explore/masternodes/index.page.tsx
+++ b/src/pages/explore/masternodes/index.page.tsx
@@ -1,17 +1,17 @@
-import { Container } from "@components/commons/Container";
+// import { Container } from "@components/commons/Container";
 import { SSRConfig, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { HeroBanner, HeroBannerBg } from "@components/commons/HeroBanner";
-import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
+// import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
 import { MasternodesStatisticsDisplay } from "./_components/MasternodesStatisticsDisplay";
 import { MasternodesBenefitsSection } from "./MasternodesBenefitsSection";
 
 export default function ExploreMasternodes() {
   const { t } = useTranslation("page-explore-masternodes");
-  const entries: Array<{ title: string; subtitle: string }> = t(
-    "footerCards.cards",
-    { returnObjects: true }
-  );
+  // const entries: Array<{ title: string; subtitle: string }> = t(
+  //   "footerCards.cards",
+  //   { returnObjects: true }
+  // );
   return (
     <>
       <HeroBanner
@@ -24,7 +24,8 @@ export default function ExploreMasternodes() {
       />
       <MasternodesStatisticsDisplay />
       <MasternodesBenefitsSection />
-      <Container className="lg:mb-8 md:mb-6 mb-4">
+      {/* TODO: uncomment after mvp */}
+      {/* <Container className="lg:mb-8 md:mb-6 mb-4">
         <div className="flex flex-row overflow-x-scroll lg:gap-x-8 md:gap-x-6 gap-x-4">
           <ExploreCards
             title={t("footerCards.cardTitle")}
@@ -39,7 +40,7 @@ export default function ExploreMasternodes() {
             href="/explore/dfi"
           />
         </div>
-      </Container>
+      </Container> */}
     </>
   );
 }

--- a/src/pages/explore/wallets/_components/DynamicDownloadCard.tsx
+++ b/src/pages/explore/wallets/_components/DynamicDownloadCard.tsx
@@ -76,6 +76,7 @@ export function DynamicDownloadCard(
             {Object.keys(props.keywords).map((key) =>
               downloadLinks && downloadLinks[key] ? (
                 <CardLink
+                  key={key}
                   descText="Download for"
                   text={IconType[OSIconMapping[key]]}
                   url={downloadLinks[key]}

--- a/src/pages/explore/wallets/index.page.tsx
+++ b/src/pages/explore/wallets/index.page.tsx
@@ -1,17 +1,17 @@
-import { Container } from "@components/commons/Container";
+// import { Container } from "@components/commons/Container";
 import { SSRConfig, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { HeroBanner, HeroBannerBg } from "@components/commons/HeroBanner";
-import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
+// import { ExploreCards, ExploreCardsImage } from "../_components/ExploreCards";
 import { AdvanceUsageSection } from "./_components/AdvanceUsageSection";
 import { ForDailyUseSection } from "./_components/ForDailyUseSection";
 
 export default function ExploreWallets() {
   const { t } = useTranslation("page-explore-wallets");
-  const entries: Array<{ title: string; subtitle: string }> = t(
-    "footerCards.cards",
-    { returnObjects: true }
-  );
+  // const entries: Array<{ title: string; subtitle: string }> = t(
+  //   "footerCards.cards",
+  //   { returnObjects: true }
+  // );
   return (
     <>
       <HeroBanner
@@ -24,7 +24,8 @@ export default function ExploreWallets() {
       />
       <ForDailyUseSection />
       <AdvanceUsageSection />
-      <Container className="lg:mb-8 md:mb-6 mb-4">
+      {/* TODO: uncomment after mvp */}
+      {/* <Container className="lg:mb-8 md:mb-6 mb-4">
         <div className="flex flex-row overflow-x-scroll lg:gap-x-8 md:gap-x-6 gap-x-4">
           <ExploreCards
             title={t("footerCards.cardTitle")}
@@ -39,7 +40,7 @@ export default function ExploreWallets() {
             href="/explore/dfi"
           />
         </div>
-      </Container>
+      </Container> */}
     </>
   );
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- As titled
- Hide CTA buttons, explore cards and dfi price from exchange
- Update button padding
- Add key to .map element
- Add link to CTA on homepage
- Remove unused code

#### Additional comments?:
