### PR TITLE
fix(ui-ux): fix to use overflow hidden instead of overflow clip 

### DIFF
--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -89,14 +89,16 @@ export function Default(props: PropsWithChildren<any>): JSX.Element | null {
         <WhaleProvider>
           <div className="bg-dark-00 relative z-0">
             <Header />
-            <main className="flex-grow text-dark-1000">{props.children}</main>
-            <div
-              className={classNames(
-                "absolute z-[-1] bg-top bg-no-repeat inset-0",
-                bgPicture
-              )}
-            />
-            <Footer />
+            <div className="overflow-x-hidden">
+              <main className="flex-grow text-dark-1000">{props.children}</main>
+              <div
+                className={classNames(
+                  "absolute z-[-1] bg-top bg-no-repeat inset-0",
+                  bgPicture
+                )}
+              />
+              <Footer />
+            </div>
           </div>
         </WhaleProvider>
       )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,7 +14,6 @@
 @tailwind utilities;
 
 body {
-  overflow-x: clip;
   width: 100%;
   box-sizing: border-box;
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR is to use overflow-hidden instead of overflow-clip as overflow-clip might not be supported in some iOS version

#### Additional comments?:
