### PR TITLE
fix(ui-ux): fix homepage padding between statistics and blockchain section

### DIFF
--- a/src/components/index/BlockchainFeaturesSection.tsx
+++ b/src/components/index/BlockchainFeaturesSection.tsx
@@ -43,7 +43,7 @@ export function BlockchainFeaturesSection(): JSX.Element {
 
   return (
     <section
-      className="lg:py-[156px] md:py-24 pt-[80px] pb-12"
+      className="lg:py-[156px] md:py-24 pt-20 pb-12"
       data-testid="BlockchainFeatureSection"
     >
       <Container className="flex flex-col justify-between lg:flex-row 2xl:max-w-[1920px] 2xl:mx-[300px]">

--- a/src/components/index/BlockchainFeaturesSection.tsx
+++ b/src/components/index/BlockchainFeaturesSection.tsx
@@ -43,7 +43,7 @@ export function BlockchainFeaturesSection(): JSX.Element {
 
   return (
     <section
-      className="pt-14 pb-12 md:py-24 lg:py-[156px]"
+      className="lg:py-[156px] md:py-24 pt-[80px] pb-12"
       data-testid="BlockchainFeatureSection"
     >
       <Container className="flex flex-col justify-between lg:flex-row 2xl:max-w-[1920px] 2xl:mx-[300px]">

--- a/src/components/index/StatisticsDisplay.tsx
+++ b/src/components/index/StatisticsDisplay.tsx
@@ -80,7 +80,7 @@ export function StatsDisplay() {
       <div
         className={classNames(
           "absolute z-[-1] bg-contain bg-no-repeat bg-left bg-[url(/assets/img/index/index-cube.png)]",
-          "lg:top-0 md:top-[84px] top-[108px] lg:left-[-200px] -left-20",
+          "lg:top-0 md:top-[65px] top-[108px] lg:left-[-200px] md:-left-[12em] -left-20",
           "2xl:w-full 2xl:h-[600px] 2xl:left-[-600.86px] lg:w-full lg:h-[400px] md:w-[280px] md:h-[280px] w-[208px] h-[208px]"
         )}
       />


### PR DESCRIPTION
…ion title in homepage

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- This PR fixes the padding between the statistics display and blockchain section in mobile view 
- This PR also fixes the position of the cube bg in tablet mode for the statistics section in homepage

#### Additional comments?:
