### PR TITLE
fix(ui-ux): added fix for overflow and stick as well as assets shifting

### DIFF
--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import { PropsWithChildren, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import classNames from "classnames";
+import { useDeviceDetect, ViewPort } from "@hooks/useDeviceDetect";
 import Footer from "./components/Footer";
 import { Header } from "./components/Header";
 import { WhaleProvider } from "./context/WhaleContext";
@@ -21,6 +22,7 @@ export function Default(props: PropsWithChildren<any>): JSX.Element | null {
   const bgPicture = isHome
     ? "bg-[url(/assets/img/background/background-320.png)] sm:bg-[url(/assets/img/background/background-768.png)] md:bg-[url(/assets/img/background/background-1024.png)] lg:bg-[url(/assets/img/background/background-1440.png)] 2xl:bg-[url(/assets/img/background/background-1920.png)]"
     : "";
+  const device = useDeviceDetect();
 
   useEffect(() => {
     setMounted(true);
@@ -89,7 +91,13 @@ export function Default(props: PropsWithChildren<any>): JSX.Element | null {
         <WhaleProvider>
           <div className="bg-dark-00 relative z-0">
             <Header />
-            <div className="overflow-x-hidden">
+            <div
+              className={classNames(
+                device === ViewPort.DESKTOP
+                  ? "overflow-x-clip"
+                  : "overflow-x-hidden"
+              )}
+            >
               <main className="flex-grow text-dark-1000">{props.children}</main>
               <div
                 className={classNames(

--- a/src/pages/explore/dfi/_components/HarnessDFISection.tsx
+++ b/src/pages/explore/dfi/_components/HarnessDFISection.tsx
@@ -82,7 +82,7 @@ export default function HarnessDFISection() {
       <div className="flex justify-center mt-16 hidden md:flex">
         <HarnessDFIGrid gridItems={harnessDFIItems} />
       </div>
-      <div className="block md:hidden mt-16">
+      <div className="block md:hidden mt-16 h-[660px]">
         <Slider {...sliderSettings}>
           <HarnessDFIGrid gridItems={harnessDFIItems.slice(0, 3)} isMobile />
           <HarnessDFIGrid gridItems={harnessDFIItems.slice(3)} isMobile />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR updates to use overflow clip in desktop view and overflow hidden in tablet and mobile
This PR also updates HarnessDFI section in explore/dfi to fix the height so that assets will not shift when slide to next page in the section

#### Additional comments?:
