### PR TITLE
chore(e2e): explore-dex

### DIFF
--- a/cypress/e2e/explore/dex.spec.ts
+++ b/cypress/e2e/explore/dex.spec.ts
@@ -21,5 +21,75 @@ viewports.forEach((viewport) => {
         "Trade, Arbitrage and Earn in a DEX which empowers you with full control."
       );
     });
+
+    it("should have Start exploring button visible and navigate to the expected area", () => {
+      cy.findByTestId("start-exploring-button").scrollIntoView();
+      if (viewport === "macbook-16") {
+        cy.findByTestId("start-exploring-button").click({
+          scrollBehavior: false,
+        });
+        cy.url().should("include", "#explore-dex-statistics-display");
+      }
+      cy.checkElementVisibilityAndText(
+        "statistic-title-total-value-locked",
+        "TOTAL VALUE LOCKED"
+      );
+      cy.checkElementVisibilityAndText(
+        "statistic-title-trading-volume",
+        "TRADING VOLUME (24H)"
+      );
+      cy.checkElementVisibilityAndText(
+        "statistic-title-statistics-display-tokens",
+        "TOKENS"
+      );
+    });
+
+    it("should have Why DEX section visible and expected text", () => {
+      cy.checkElementVisibilityAndText("title", "Why DEX?");
+      cy.checkElementVisibilityAndText(
+        "desc",
+        "Experience trustless trading, arbitrage, and earnings with DeFiChain DEX's wide array of liquidity pools."
+      );
+
+      cy.checkElementVisibilityAndHref(
+        "secondary-button-explore-dex",
+        "https://defiscan.live/dex"
+      );
+    });
+
+    it("should have Why DEX elements visible and expected text", () => {
+      cy.checkElementVisibilityAndText(
+        "dex-trade-assets-title",
+        "TRADE ASSETS"
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-trade-assets-desc",
+        "Seamlessly swap tokens with ease and convenience."
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-wide-selection-of-tokens-title",
+        "WIDE SELECTION OF TOKENS"
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-wide-selection-of-tokens-desc",
+        "Discover endless possibilities with 60+ dTokens - Your key to a diverse DeFi playground."
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-profit-from-liquidity-mining-title",
+        "PROFIT FROM LIQUIDITY MINING"
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-profit-from-liquidity-mining-desc",
+        "Contribute liquidity, earn rewards, and withdraw whenever you want."
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-advanced-swaps-title",
+        "ADVANCED SWAPS"
+      );
+      cy.checkElementVisibilityAndText(
+        "dex-advanced-swaps-desc",
+        "Instant multi-pool trades or future-price-based dToken swaps at your fingertips."
+      );
+    });
   });
 });

--- a/cypress/e2e/explore/dex.spec.ts
+++ b/cypress/e2e/explore/dex.spec.ts
@@ -1,0 +1,25 @@
+const viewports = ["iphone-xr", "ipad-2", "macbook-16"];
+
+viewports.forEach((viewport) => {
+  context(`/explore/dex on ${viewport}`, () => {
+    beforeEach(() => {
+      cy.visit("/explore/dex");
+      cy.viewport(<Cypress.ViewportPreset>viewport);
+    });
+
+    it("should have DEX header section visible and expected text", () => {
+      cy.checkElementVisibilityAndText(
+        "section-title-explore-dex-decentralized-exchange",
+        "DECENTRALIZED EXCHANGE"
+      );
+      cy.checkElementVisibilityAndText(
+        "section-header-explore-dex-decentralized-exchange",
+        "Trade effortlessly with DeFiChain DEX"
+      );
+      cy.checkElementVisibilityAndText(
+        "section-desc-explore-dex-decentralized-exchange",
+        "Trade, Arbitrage and Earn in a DEX which empowers you with full control."
+      );
+    });
+  });
+});

--- a/src/components/commons/SectionDescription.tsx
+++ b/src/components/commons/SectionDescription.tsx
@@ -9,6 +9,7 @@ export function SectionDescription({
 }) {
   return (
     <div
+      data-testid="section-desc-explore-dex-decentralized-exchange"
       className={classNames(
         "font-desc tracking-[0.03em] text-xl text-dark-700",
         "lg:text-2xl tracking-normal",

--- a/src/components/commons/SectionSubTitle.tsx
+++ b/src/components/commons/SectionSubTitle.tsx
@@ -9,6 +9,7 @@ export function SectionSubTitle({
 }) {
   return (
     <h1
+      data-testid="section-header-explore-dex-decentralized-exchange"
       className={classNames(
         "text-dark-1000 text-[40px] leading-[44px] tracking-[-0.02em]",
         "md:text-5xl md:leading-[52px] md:tracking-normal",

--- a/src/pages/explore/masternodes/SvgIconsColumn.tsx
+++ b/src/pages/explore/masternodes/SvgIconsColumn.tsx
@@ -70,6 +70,7 @@ export function SvgIconsColumn({
     </div>
   );
 }
+// testId: string;
 
 function FeatureIcon({
   item,
@@ -124,6 +125,9 @@ function FeatureIcon({
         )}
       >
         <h3
+          data-testid={`dex-${item.title
+            .toLowerCase()
+            .replaceAll(" ", "-")}-title`}
           className={classNames(
             "font-bold leading-5 text-dark-1000 transition duration-300 ease-in-out"
             // {
@@ -133,7 +137,12 @@ function FeatureIcon({
         >
           {item.title}
         </h3>
-        <p className="text-dark-700 text-sm pr-[26px] md:pr-0 md:w-[206px] lg:text-base font-desc">
+        <p
+          data-testid={`dex-${item.title
+            .toLowerCase()
+            .replaceAll(" ", "-")}-desc`}
+          className="text-dark-700 text-sm pr-[26px] md:pr-0 md:w-[206px] lg:text-base font-desc"
+        >
           {item.desc}
         </p>
       </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- should have DEX header section visible and expected text 
- should have Start exploring button visible and navigate to the expected area 
- should have Why DEX section visible and expected text 
- should have Why DEX elements visible and expected text

NOTE: some of test ids rely on title fields
#### Additional comments?:
