### PR TITLE
chore(e2e): explore-masternodes

### DIFF
--- a/cypress/e2e/explore/dex.spec.ts
+++ b/cypress/e2e/explore/dex.spec.ts
@@ -58,36 +58,33 @@ viewports.forEach((viewport) => {
     });
 
     it("should have Why DEX elements visible and expected text", () => {
+      cy.checkElementVisibilityAndText("trade-assets-title", "TRADE ASSETS");
       cy.checkElementVisibilityAndText(
-        "dex-trade-assets-title",
-        "TRADE ASSETS"
-      );
-      cy.checkElementVisibilityAndText(
-        "dex-trade-assets-desc",
+        "trade-assets-desc",
         "Seamlessly swap tokens with ease and convenience."
       );
       cy.checkElementVisibilityAndText(
-        "dex-wide-selection-of-tokens-title",
+        "wide-selection-of-tokens-title",
         "WIDE SELECTION OF TOKENS"
       );
       cy.checkElementVisibilityAndText(
-        "dex-wide-selection-of-tokens-desc",
+        "wide-selection-of-tokens-desc",
         "Discover endless possibilities with 60+ dTokens - Your key to a diverse DeFi playground."
       );
       cy.checkElementVisibilityAndText(
-        "dex-profit-from-liquidity-mining-title",
+        "profit-from-liquidity-mining-title",
         "PROFIT FROM LIQUIDITY MINING"
       );
       cy.checkElementVisibilityAndText(
-        "dex-profit-from-liquidity-mining-desc",
+        "profit-from-liquidity-mining-desc",
         "Contribute liquidity, earn rewards, and withdraw whenever you want."
       );
       cy.checkElementVisibilityAndText(
-        "dex-advanced-swaps-title",
+        "advanced-swaps-title",
         "ADVANCED SWAPS"
       );
       cy.checkElementVisibilityAndText(
-        "dex-advanced-swaps-desc",
+        "advanced-swaps-desc",
         "Instant multi-pool trades or future-price-based dToken swaps at your fingertips."
       );
     });

--- a/cypress/e2e/explore/dex.spec.ts
+++ b/cypress/e2e/explore/dex.spec.ts
@@ -1,4 +1,4 @@
-const viewports = ["iphone-xr", "ipad-2", "macbook-16"];
+import { viewports } from "../../fixture/main.config";
 
 viewports.forEach((viewport) => {
   context(`/explore/dex on ${viewport}`, () => {

--- a/cypress/e2e/explore/dfi.spec.ts
+++ b/cypress/e2e/explore/dfi.spec.ts
@@ -1,6 +1,5 @@
 import { exchanges } from "../../fixture/dfi.config";
-
-const viewports = ["iphone-xr", "ipad-2", "macbook-16"];
+import { viewports } from "../../fixture/main.config";
 
 viewports.forEach((viewport) => {
   context(`/explore/dfi on ${viewport}`, () => {

--- a/cypress/e2e/explore/masternodes.spec.ts
+++ b/cypress/e2e/explore/masternodes.spec.ts
@@ -1,0 +1,10 @@
+import { viewports } from "../../fixture/main.config";
+
+viewports.forEach((viewport) => {
+  context(`/explore/masternodes on ${viewport}`, () => {
+    beforeEach(() => {
+      cy.visit("/explore/masternodes");
+      cy.viewport(<Cypress.ViewportPreset>viewport);
+    });
+  });
+});

--- a/cypress/e2e/explore/masternodes.spec.ts
+++ b/cypress/e2e/explore/masternodes.spec.ts
@@ -1,10 +1,67 @@
 import { viewports } from "../../fixture/main.config";
+import { masternodeElements } from "../../fixture/masternodes.config";
 
 viewports.forEach((viewport) => {
   context(`/explore/masternodes on ${viewport}`, () => {
     beforeEach(() => {
       cy.visit("/explore/masternodes");
       cy.viewport(<Cypress.ViewportPreset>viewport);
+    });
+
+    it("should have Learn About Masternodes section visible and expected text", () => {
+      cy.checkElementVisibilityAndText(
+        "section-title-explore-masternodes-learn-about-masternodes",
+        "LEARN ABOUT MASTERNODES"
+      );
+      cy.checkElementVisibilityAndText(
+        "section-header-explore-dex-decentralized-exchange",
+        "DeFiChain Masternodes"
+      );
+      cy.checkElementVisibilityAndText(
+        "section-desc-explore-dex-decentralized-exchange",
+        "Secure, incentivized, community-driven nodes powering DeFiChain."
+      );
+    });
+
+    it("should have Start exploring button visible and navigate to the expected area", () => {
+      cy.findByTestId("start-exploring-button").scrollIntoView();
+      if (viewport === "macbook-16") {
+        cy.findByTestId("start-exploring-button").click({
+          scrollBehavior: false,
+        });
+        cy.url().should("include", "#statistics_display_masternodes");
+      }
+      cy.checkElementVisibilityAndText(
+        "statistic-title-masternodes",
+        "MASTERNODES"
+      );
+      cy.checkElementVisibilityAndText(
+        "statistic-title-tvl",
+        "TOTAL VALUE LOCKED"
+      );
+    });
+
+    it("should have Own A Masternode section displayed and with expected text", () => {
+      cy.checkElementVisibilityAndText(
+        "section-title-masternodes-benefits-section",
+        "OWN A MASTERNODE"
+      );
+      cy.checkElementVisibilityAndText("title", "Benefits of Masternodes");
+      cy.checkElementVisibilityAndText(
+        "desc",
+        "Unlock the full utility of DeFiChain with a masternode."
+      );
+
+      cy.checkElementVisibilityAndHref(
+        "explore-dmc-button-masternodes-benefits-section",
+        "/explore/masternodes/technical-guide"
+      );
+    });
+
+    it("should have Own A Masternode elements visible and expected text", () => {
+      masternodeElements.forEach((element) => {
+        cy.checkElementVisibilityAndText(element.id, element.text);
+      });
     });
   });
 });

--- a/cypress/e2e/homepage.spec.ts
+++ b/cypress/e2e/homepage.spec.ts
@@ -1,6 +1,5 @@
 import { ecosystemLinks, resourcesLinks } from "../fixture/homepage.config";
-
-const viewports = ["macbook-16", "iphone-xr", "ipad-2"];
+import { viewports } from "../fixture/main.config";
 
 viewports.forEach((viewport) => {
   context(`Homepage on ${viewport}`, () => {

--- a/cypress/fixture/main.config.ts
+++ b/cypress/fixture/main.config.ts
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const viewports = ["macbook-16", "iphone-xr", "ipad-2"];

--- a/cypress/fixture/masternodes.config.ts
+++ b/cypress/fixture/masternodes.config.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/prefer-default-export */
+export const viewports = ["macbook-16", "iphone-xr", "ipad-2"];
+
+export const masternodeElements = [
+  { id: "passive-income-title", text: "PASSIVE INCOME" },
+  {
+    id: "passive-income-desc",
+    text: "Earn a portion of block rewards and transaction fees",
+  },
+  { id: "staking-rewards-title", text: "STAKING REWARDS" },
+  {
+    id: "staking-rewards-desc",
+    text: "Reap the exclusive benefits of masternode staking",
+  },
+  { id: "network-security-title", text: "NETWORK SECURITY" },
+  {
+    id: "network-security-desc",
+    text: "Secure transactions by validating transactions",
+  },
+  { id: "governance-title", text: "GOVERNANCE" },
+  {
+    id: "governance-desc",
+    text: "Make a difference with your vote on DeFiChain governance proposals",
+  },
+];

--- a/src/pages/explore/masternodes/SvgIconsColumn.tsx
+++ b/src/pages/explore/masternodes/SvgIconsColumn.tsx
@@ -125,9 +125,7 @@ function FeatureIcon({
         )}
       >
         <h3
-          data-testid={`dex-${item.title
-            .toLowerCase()
-            .replaceAll(" ", "-")}-title`}
+          data-testid={`${item.title.toLowerCase().replaceAll(" ", "-")}-title`}
           className={classNames(
             "font-bold leading-5 text-dark-1000 transition duration-300 ease-in-out"
             // {
@@ -138,9 +136,7 @@ function FeatureIcon({
           {item.title}
         </h3>
         <p
-          data-testid={`dex-${item.title
-            .toLowerCase()
-            .replaceAll(" ", "-")}-desc`}
+          data-testid={`${item.title.toLowerCase().replaceAll(" ", "-")}-desc`}
           className="text-dark-700 text-sm pr-[26px] md:pr-0 md:w-[206px] lg:text-base font-desc"
         >
           {item.desc}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
1. Moved viewport setting to main config
2. Added next tests for masternodes section:
- should have Learn About Masternodes section visible and expected text 
- should have Start exploring button visible and navigate to the expected area 
- should have Own A Masternode section displayed and with expected text 
- should have Own A Masternode elements visible and expected text


#### Additional comments?:
