### PR TITLE
fix(route): update routing for `/learn` and its child pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,7 +64,7 @@ module.exports = {
   async redirects() {
     return [
       {
-        source: "/learn",
+        source: "/learn/:path*",
         destination: "/404",
         permanent: false,
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Using wildcard matching, this PR will redirect `/learn` and its child paths to `/404` since the child routes aren't the same as the new ones:
e.g. old route: `/learn/run-a-masternode` new route: `/explore/masternodes`

#### Additional comments?:
