### PR TITLE
Issue#15: Light Wallet Google Play Store icon leads to dead URL

### DIFF
--- a/src/pages/explore/wallets/_components/ForDailyUseSection.tsx
+++ b/src/pages/explore/wallets/_components/ForDailyUseSection.tsx
@@ -54,7 +54,9 @@ export function ForDailyUseSection() {
               text={IconType.APPSTORE}
             />
             <CardLink
-              url="https://play.google.com/store/apps/details?id=com.defichain.app"
+              // Temporarily link until the app is available on Google Play
+              // url="https://play.google.com/store/apps/details?id=com.defichain.app"
+              url="https://www.reddit.com/r/defiblockchain/comments/1n1figg/update_on_the_missing_light_wallet_in_the_google/"
               descText="Get It On"
               text={IconType.GOOGLE_PLAY}
             />


### PR DESCRIPTION
This PR updates the Light Wallet Google Play Store icon link to point to the correct information page instead of a dead URL.